### PR TITLE
セルの書式設定が「!¥ 0;- !¥ 0;!¥ 0;''」の場合、例外が発生するので、セクションが4つの場合の処理を追加した

### DIFF
--- a/src/main/java/com/github/mygreen/cellformatter/CustomFormatterFactory.java
+++ b/src/main/java/com/github/mygreen/cellformatter/CustomFormatterFactory.java
@@ -13,13 +13,13 @@ import com.github.mygreen.cellformatter.tokenizer.TokenStore;
  *
  */
 public class CustomFormatterFactory {
-    
+
     private ConditionTextFormatterFactory textFormatterFactory = new ConditionTextFormatterFactory();
-    
+
     private ConditionDateFormatterFactory dateFormatterFactory = new ConditionDateFormatterFactory();
-    
+
     private ConditionNumberFormatterFactory numberFormatterFactory = new ConditionNumberFormatterFactory();
-    
+
     /**
      * 書式を元に、{@link CustomFormatter}のインスタンスを作成する。
      * @param pattern ユーザ定義の書式
@@ -27,60 +27,60 @@ public class CustomFormatterFactory {
      * @throws CustomFormatterParseException 書式が不正な場合にスローされる。
      */
     public CustomFormatter create(final String pattern) {
-        
+
         final CustomFormatTokenizer tokenizer = new CustomFormatTokenizer();
         final TokenStore allStore = tokenizer.parse(pattern);
         if(allStore.getTokens().isEmpty()) {
             // 標準のフォーマッタ
             return CustomFormatter.DEFAULT_FORMATTER;
-            
+
         } else if(pattern.equalsIgnoreCase("General")) {
             return CustomFormatter.DEFAULT_FORMATTER;
         }
-        
+
         // セクション単位に分割し、処理していく。
         final List<TokenStore> sections = allStore.split(Token.SYMBOL_SEMI_COLON);
         if(sections.size() > 4) {
             throw new CustomFormatterParseException(pattern,
                     String.format("section size over 4. but '%s' number of %d secitions.", pattern, sections.size()));
         }
-        
+
         final CustomFormatter formatter = new CustomFormatter(pattern);
         boolean containsTextFormatter = false;
         for(TokenStore section : sections) {
-            
+
             final ConditionFormatter conditionFormatter;
             if(textFormatterFactory.isTextPattern(section)) {
                 conditionFormatter = textFormatterFactory.create(section);
                 containsTextFormatter = true;
-                
+
             } else if(dateFormatterFactory.isDatePattern(section)) {
                 conditionFormatter = dateFormatterFactory.create(section);
-                
+
             } else if(numberFormatterFactory.isNumberPattern(section)) {
                 conditionFormatter = numberFormatterFactory.create(section);
-                
+
             } else {
                 conditionFormatter = numberFormatterFactory.create(section);
-                
+
             }
-            
+
             formatter.addConditionFormatter(conditionFormatter);
-            
+
         }
-        
+
         // 条件式の設定
         int sectionSize = sections.size();
         if(containsTextFormatter) {
             // 文字列の書式を含む場合は、個数から除外する。
             sectionSize--;
         }
-        
+
         // 1番目の書式がデフォルトの条件の場合
         boolean hasConditionFirst = false;
-        
+
         for(int i=0; i < sectionSize; i++) {
-            
+
             final ConditionFormatter conditionFormatter = formatter.getConditionFormatters().get(i);
             if(conditionFormatter.getOperator() != null) {
                 if(i == 0) {
@@ -88,16 +88,16 @@ public class CustomFormatterFactory {
                 }
                 continue;
             }
-            
+
             if(sectionSize <= 1) {
                 // 書式が1つしかない場合
                 conditionFormatter.setOperator(ConditionOperator.ALL);
-                
+
             } else if(sectionSize == 2) {
                 if(i==0) {
                     // ゼロ以上の数の書式
                     conditionFormatter.setOperator(ConditionOperator.NON_NEGATIVE);
-                    
+
                 } else if(i==1) {
                     // その他の書式
                     if(hasConditionFirst) {
@@ -106,30 +106,49 @@ public class CustomFormatterFactory {
                         conditionFormatter.setOperator(ConditionOperator.NEGATIVE);
                     }
                 }
-                
+
             } else if(sectionSize == 3) {
                 if(i==0) {
                     // 正の書式
                     conditionFormatter.setOperator(ConditionOperator.POSITIVE);
-                    
+
                 } else if(i==1) {
                     // 負の数の書式
                     conditionFormatter.setOperator(ConditionOperator.NEGATIVE);
-                    
+
                 } else {
                     // その他の書式
                     conditionFormatter.setOperator(ConditionOperator.ALL);
-                    
+
                 }
-                
-            } else {
+
+            } else if(sectionSize == 4) {
+                if(i==0) {
+                    // 正の書式
+                    conditionFormatter.setOperator(ConditionOperator.POSITIVE);
+
+                } else if(i==1) {
+                    // 負の数の書式
+                    conditionFormatter.setOperator(ConditionOperator.NEGATIVE);
+
+                } else if(i==2) {
+                    // ゼロの書式
+                    conditionFormatter.setOperator(ConditionOperator.ZERO);
+
+                } else {
+                    // その他の書式
+                    conditionFormatter.setOperator(ConditionOperator.ALL);
+
+                }
+
+        	} else {
                 throw new CustomFormatterParseException(pattern,
-                        String.format("section size over 4. but '%s' number of %d secitions.", pattern, sections.size())); 
+                        String.format("section size over 4. but '%s' number of %d secitions.", pattern, sections.size()));
             }
-            
+
         }
-        
+
         return formatter;
     }
-    
+
 }

--- a/src/test/java/com/github/mygreen/cellformatter/CustomFormatterFactoryTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/CustomFormatterFactoryTest.java
@@ -14,76 +14,76 @@ import com.github.mygreen.cellformatter.lang.MSColor;
  *
  */
 public class CustomFormatterFactoryTest {
-    
+
     // エスケープ文字のテスト
     @Test
     public void testEscapedChar() {
-        
+
         CommonCell testCell = new TestNumberCell(23.1, (short)0, "*a!a!a##.00");
         CustomFormatterFactory factory = new CustomFormatterFactory();
         CustomFormatter formatter = factory.create(testCell.getFormatPattern());
-        
+
         CellFormatResult actual = formatter.format(testCell);
         assertThat(actual.getText(), is("aa23.10"));
     }
-    
+
     // エスケープ文字のテスト
     @Test
     public void testEscapedChar2() {
-        
+
         // "\"#,##0_);[Red]\("\"#,##0\)
         NumberCell<Integer> cell = new NumberCell<Integer>(-1234, "\"\\\"#,##0_);[Red]\\(\"\\\"#,##0\\)");
-        
+
         CustomFormatterFactory factory = new CustomFormatterFactory();
         CustomFormatter formatter = factory.create(cell.getFormatPattern());
-        
+
         CellFormatResult actual = formatter.format(cell);
         assertThat(actual.getText(), is("(\\1,234)"));
         assertThat(actual.getTextColor(), is(MSColor.RED));
     }
-    
+
     // セクションの個数のテスト
     @Test
     public void testSectionNumber() {
-        
+
         CustomFormatterFactory factory = new CustomFormatterFactory();
-        
+
         try {
             // 4つの場合
             factory.create("###1;###2;###3;4@");
-            
+            factory.create("!¥ 0;- !¥ 0;!¥ 0;''");
         } catch(Exception e) {
             e.printStackTrace();
             fail();
         }
-        
+
         try {
             // 5つの場合
             factory.create("###1;###2;###3;###4;5@");
             fail();
         } catch(Exception e) {
-            
+
             assertThat(e, instanceOf(CustomFormatterParseException.class));
         }
-        
+
     }
-    
+
     // フォーマット結果のテスト
     @Test
     public void testCellFormatResult() {
-        
+
         CommonCell testCell = new TestNumberCell(100.1, (short)0, "[赤][>100]\">\"##.0#;[青][=100]\"=\"##.0#;[紫]\"その他\"##.0#");
-        
+
         CustomFormatterFactory factory = new CustomFormatterFactory();
         CustomFormatter formatter = factory.create(testCell.getFormatPattern());
-        
+
         CellFormatResult actual = formatter.format(testCell);
-        
+
         assertThat(actual.getValueAsDoulbe(), is(100.1));
         assertThat(actual.getText(), is(">100.1"));
         assertThat(actual.getTextColor(), is(MSColor.RED));
         assertThat(actual.getSectionPattern(), is("[赤][>100]\">\"##.0#"));
         assertThat(actual.getCellType(), is(FormatCellType.Number));
-        
+
     }
 }


### PR DESCRIPTION
セルの書式設定が「!¥ 0;- !¥ 0;!¥ 0;''」の場合、下記の例外が発生しました。
com.github.mygreen.cellformatter.CustomFormatterParseException: section size over 4. but '\¥\ 0;\-\ \¥\ 0;\¥\ 0;\'\'' number of 4 secitions.
	at com.github.mygreen.cellformatter.CustomFormatterFactory.create(CustomFormatterFactory.java:126)

126行目の箇所にセクションが4つのケースがないので、エラーが発生すると思い、追加処理をすると大丈夫でした。
xlsmapperを使用していますが、客先からの変更できないExcelを読み込むとエラーが発生します。また、xlsmapperのexcel-cellformatterの参照先変更の方法が分かりません。マージして頂けると助かります。