### PR TITLE
POI v4.1に対応

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Set up Time-Zone
       run: sudo timedatectl set-timezone Asia/Tokyo
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.7
+    - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.7
+        java-version: 1.8
     - name: Build with Maven
       run: mvn -B clean verify -Dgpg.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@ Excelのセルの書式を解析してフォーマットするライブラリ。
 	</developers>
 
 	<properties>
-		<java.version>1.7</java.version>
-		<poi.version>3.17</poi.version>
-		<jexcelapi.version>2.6.10</jexcelapi.version>
+		<java.version>1.8</java.version>
+		<poi.version>4.1.2</poi.version>
+		<jexcelapi.version>2.6.12</jexcelapi.version>
 		<slf4j.version>1.7.1</slf4j.version>
 		<jacoco.include.package>com.github.mygreen.cellformatter.*</jacoco.include.package>
 

--- a/pom.xml
+++ b/pom.xml
@@ -203,8 +203,8 @@ Excelのセルの書式を解析してフォーマットするライブラリ。
 					<locale>ja_JP</locale>
 					<maxmemory>512m</maxmemory>
 					<links>
-						<link>http://docs.oracle.com/javase/jp/7/api/</link>
-						<link>http://poi.apache.org/apidocs/</link>
+						<link>https://docs.oracle.com/javase/jp/8/docs/api/</link>
+						<link>https://poi.apache.org/apidocs/4.1/</link>
 						<link>http://jexcelapi.sourceforge.net/resources/javadocs/2_6_10/docs/</link>
 					</links>
 					<stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
@@ -424,8 +424,8 @@ $(document).ready(function() {
 					<docencoding>UTF-8</docencoding>
 					<locale>ja_JP</locale>
 					<links>
-						<link>http://docs.oracle.com/javase/jp/7/api/</link>
-						<link>http://poi.apache.org/apidocs/</link>
+						<link>https://docs.oracle.com/javase/jp/8/docs/api/</link>
+						<link>https://poi.apache.org/apidocs/4.1/</link>
 						<link>http://jexcelapi.sourceforge.net/resources/javadocs/2_6_10/docs/</link>
 					</links>
 					<stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>

--- a/src/main/java/com/github/mygreen/cellformatter/POICell.java
+++ b/src/main/java/com/github/mygreen/cellformatter/POICell.java
@@ -73,7 +73,7 @@ public class POICell implements CommonCell {
 
     @Override
     public boolean isText() {
-        return cell.getCellTypeEnum() == CellType.STRING;
+        return cell.getCellType() == CellType.STRING;
     }
 
     @Override
@@ -83,7 +83,7 @@ public class POICell implements CommonCell {
 
     @Override
     public boolean isBoolean() {
-        return cell.getCellTypeEnum() == CellType.BOOLEAN;
+        return cell.getCellType() == CellType.BOOLEAN;
     }
 
     @Override
@@ -93,7 +93,7 @@ public class POICell implements CommonCell {
 
     @Override
     public boolean isNumber() {
-        return cell.getCellTypeEnum() == CellType.NUMERIC;
+        return cell.getCellType() == CellType.NUMERIC;
     }
 
     @Override

--- a/src/main/java/com/github/mygreen/cellformatter/POICellFormatter.java
+++ b/src/main/java/com/github/mygreen/cellformatter/POICellFormatter.java
@@ -132,7 +132,7 @@ public class POICellFormatter {
 
         final Locale runtimeLocale = locale != null ? locale : Locale.getDefault();
 
-        switch(cell.getCellTypeEnum()) {
+        switch(cell.getCellType()) {
             case BLANK:
                 if(isConsiderMergedCell()) {
                     // 結合しているセルの場合、左上のセル以外に値が設定されている場合がある。
@@ -184,7 +184,7 @@ public class POICellFormatter {
      */
     private CellFormatResult getFormulaCellValue(final Cell cell, final Locale locale) {
 
-        final CellType cellType = cell.getCellTypeEnum();
+        final CellType cellType = cell.getCellType();
         assert cellType == CellType.FORMULA;
 
         final Workbook workbook = cell.getSheet().getWorkbook();
@@ -195,7 +195,7 @@ public class POICellFormatter {
             final CellValue value = evaluator.evaluate(cell);
             final POIEvaluatedCell evaluatedCell = new POIEvaluatedCell(cell, value);
 
-            switch(value.getCellTypeEnum()) {
+            switch(value.getCellType()) {
 
                 case BOOLEAN:
                     return getCellValue(evaluatedCell, locale);
@@ -235,7 +235,7 @@ public class POICellFormatter {
      */
     private CellFormatResult getErrorCellValue(final Cell cell, final Locale locale) {
 
-        final CellType cellType = cell.getCellTypeEnum();
+        final CellType cellType = cell.getCellType();
         assert cellType == CellType.ERROR;
 
         return getErrorCellValue(cell.getErrorCellValue(), locale);
@@ -293,7 +293,7 @@ public class POICellFormatter {
 
                 for(int colIdx=range.getFirstColumn(); colIdx <= range.getLastColumn(); colIdx++) {
                     final Cell valueCell = row.getCell(colIdx);
-                    if(valueCell == null || valueCell.getCellTypeEnum() == CellType.BLANK) {
+                    if(valueCell == null || valueCell.getCellType() == CellType.BLANK) {
                         continue;
                     }
 

--- a/src/main/java/com/github/mygreen/cellformatter/POIEvaluatedCell.java
+++ b/src/main/java/com/github/mygreen/cellformatter/POIEvaluatedCell.java
@@ -41,7 +41,7 @@ public class POIEvaluatedCell extends POICell {
 
     @Override
     public boolean isText() {
-        return value.getCellTypeEnum() == CellType.STRING;
+        return value.getCellType() == CellType.STRING;
     }
 
     @Override
@@ -51,7 +51,7 @@ public class POIEvaluatedCell extends POICell {
 
     @Override
     public boolean isBoolean() {
-        return value.getCellTypeEnum() == CellType.BOOLEAN;
+        return value.getCellType() == CellType.BOOLEAN;
     }
 
     @Override
@@ -61,7 +61,7 @@ public class POIEvaluatedCell extends POICell {
 
     @Override
     public boolean isNumber() {
-        return value.getCellTypeEnum() == CellType.NUMERIC;
+        return value.getCellType() == CellType.NUMERIC;
     }
 
     @Override

--- a/src/test/java/com/github/mygreen/cellformatter/POICellFormatterTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/POICellFormatterTest.java
@@ -1,8 +1,8 @@
 package com.github.mygreen.cellformatter;
 
+import static com.github.mygreen.cellformatter.lang.TestUtils.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
-import static com.github.mygreen.cellformatter.lang.TestUtils.*;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -919,7 +919,7 @@ public class POICellFormatterTest {
             
             // 特殊条件 - java8のときなど
             final String spCondition;
-            if(spConditionCell == null || spConditionCell.getCellTypeEnum().equals(CellType.BLANK)) {
+            if(spConditionCell == null || spConditionCell.getCellType() == CellType.BLANK) {
                 spCondition = "";
             } else {
                 spCondition = spConditionCell.getRichStringCellValue().toString();
@@ -970,7 +970,7 @@ public class POICellFormatterTest {
             return false;
         }
 
-        if(style.getBorderBottomEnum() == BorderStyle.NONE) {
+        if(style.getBorderBottom() == BorderStyle.NONE) {
             return false;
         }
 


### PR DESCRIPTION
- POI v3.7 -> v4.1に変更。
  - 最新版は、POI v5.0だが、Javaの前提もJava9となっており、早計として1つ下げた。
  - 非推奨となっていた列挙型取得のメソッドを変更。
- Java1.7 -> 1.8に変更。
  - POI v4.xからJava1.8が前提となったため。
  - pom.xmlのJava1.8へ変更。

