### PR TITLE
log4jのバージョンを1.2.17に変更

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@ $(document).ready(function() {
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>1.2.14</version>
+			<version>1.2.17</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
- Log4jのライブラリを1.2.14 -> 1.2.17に変更
  - 脆弱性のアラート対応 