### PR TITLE
依存ライブラリのアップデート(POI v5.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ Excelのセルの書式を解析してフォーマットするライブラリ。
 
 	<properties>
 		<java.version>1.8</java.version>
-		<poi.version>4.1.2</poi.version>
+		<poi.version>5.2.5</poi.version>
 		<jexcelapi.version>2.6.12</jexcelapi.version>
 		<slf4j.version>1.7.1</slf4j.version>
 		<jacoco.include.package>com.github.mygreen.cellformatter.*</jacoco.include.package>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ Excelのセルの書式を解析してフォーマットするライブラリ。
 		<java.version>1.8</java.version>
 		<poi.version>5.2.5</poi.version>
 		<jexcelapi.version>2.6.12</jexcelapi.version>
-		<slf4j.version>1.7.1</slf4j.version>
+		<slf4j.version>1.7.36</slf4j.version>
 		<jacoco.include.package>com.github.mygreen.cellformatter.*</jacoco.include.package>
 
 	</properties>
@@ -446,10 +446,10 @@ $(document).ready(function() {
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-			<scope>test</scope>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-reload4j</artifactId>
+		    <version>2.0.12</version>
+		    <scope>test</scope>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
- POIのバージョンを5.xの最新 v5.2.5へアップデート。
- Slf4jのバージョンを1.7.xの最新版 v1.7.36へアップデート。
  - Slf4j 2.xは、Java11以上が必須なので1.7のまま。
- log4j1.2をreload4jの最新版へアップデート。
  - reload4jは、パッケージはlog4j1.2のままでセキュリティパッチが当てられたもの。
  