### PR TITLE
テストケースの非推奨メソッドの修正/Junitのバージョン更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@ $(document).ready(function() {
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/java/com/github/mygreen/cellformatter/CustomFormatterFactoryTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/CustomFormatterFactoryTest.java
@@ -1,5 +1,6 @@
 package com.github.mygreen.cellformatter;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/github/mygreen/cellformatter/JXLCellFormatterTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/JXLCellFormatterTest.java
@@ -1,8 +1,9 @@
 package com.github.mygreen.cellformatter;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
 import static com.github.mygreen.cellformatter.lang.TestUtils.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -17,6 +18,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.github.mygreen.cellformatter.lang.JXLUtils;
+import com.github.mygreen.cellformatter.lang.MSColor;
+
 import jxl.Cell;
 import jxl.CellType;
 import jxl.Sheet;
@@ -26,14 +35,6 @@ import jxl.format.Border;
 import jxl.format.BorderLineStyle;
 import jxl.format.CellFormat;
 import jxl.read.biff.BiffException;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import com.github.mygreen.cellformatter.lang.JXLUtils;
-import com.github.mygreen.cellformatter.lang.MSColor;
 
 /**
  * JExcelAPI用のフォーマッタのテスタ

--- a/src/test/java/com/github/mygreen/cellformatter/ObjectCellFormatterTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/ObjectCellFormatterTest.java
@@ -1,8 +1,8 @@
 package com.github.mygreen.cellformatter;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
 import static com.github.mygreen.cellformatter.lang.TestUtils.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.sql.Timestamp;
 import java.util.Date;

--- a/src/test/java/com/github/mygreen/cellformatter/POICellFormatterTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/POICellFormatterTest.java
@@ -2,6 +2,7 @@ package com.github.mygreen.cellformatter;
 
 import static com.github.mygreen.cellformatter.lang.TestUtils.*;
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 import java.io.File;

--- a/src/test/java/com/github/mygreen/cellformatter/lang/EraResolverTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/lang/EraResolverTest.java
@@ -1,7 +1,7 @@
 package com.github.mygreen.cellformatter.lang;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.util.Date;
 

--- a/src/test/java/com/github/mygreen/cellformatter/lang/ExcelDateUtilsTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/lang/ExcelDateUtilsTest.java
@@ -1,7 +1,7 @@
 package com.github.mygreen.cellformatter.lang;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.math.BigDecimal;
 import java.util.Date;

--- a/src/test/java/com/github/mygreen/cellformatter/lang/MSColorTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/lang/MSColorTest.java
@@ -1,7 +1,7 @@
 package com.github.mygreen.cellformatter.lang;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.util.Locale;
 

--- a/src/test/java/com/github/mygreen/cellformatter/lang/MSLocaleTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/lang/MSLocaleTest.java
@@ -1,7 +1,7 @@
 package com.github.mygreen.cellformatter.lang;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.util.Locale;
 

--- a/src/test/java/com/github/mygreen/cellformatter/lang/MessageResolverTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/lang/MessageResolverTest.java
@@ -1,7 +1,7 @@
 package com.github.mygreen.cellformatter.lang;
 
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.util.Locale;
 

--- a/src/test/java/com/github/mygreen/cellformatter/lang/TimeCellTest.java
+++ b/src/test/java/com/github/mygreen/cellformatter/lang/TimeCellTest.java
@@ -1,7 +1,7 @@
 package com.github.mygreen.cellformatter.lang;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.io.InputStream;
 import java.nio.file.Files;


### PR DESCRIPTION
- JUnitのバージョンを4.xの最新版 v4.13.2へ変更。
- テストケースの非推奨メソッドの修正、
  - `org.junit.Assert.assertThat`  ⇒ `org.hamcrest.MatcherAssert.assertThat` へ変更。